### PR TITLE
Move PR link and title to top line and added author section

### DIFF
--- a/src/common/blocks/submit.ts
+++ b/src/common/blocks/submit.ts
@@ -413,13 +413,13 @@ export const NewSubmissionBlock = (pullRequest: PullRequest, isUpdate: boolean =
   return [
     {
       color: getAttachmentColor(pullRequest.status),
-      fallback: `<@${pullRequest.author.id}> submitted a pull request  :rocket:`,
+      fallback: `*<@${pullRequest.author.id}> - <${pullRequest.link}|${_capitalizeString(pullRequest.type)} - ${_capitalizeString(pullRequest.title)}>*  :rocket:`,
       blocks: [
         {
           type: 'section',
           text: {
             type: 'mrkdwn',
-            text: `*<@${pullRequest.author.id}> - <${pullRequest.link}|${_capitalizeString(pullRequest.type)} - ${_capitalizeString(pullRequest.title)}>*`,
+            text: `<@${pullRequest.author.id}> submitted a pull request  :rocket:\n*<${pullRequest.link}|${_capitalizeString(pullRequest.type)} - ${_capitalizeString(pullRequest.title)}>*`,
           },
           accessory,
         },

--- a/src/common/blocks/submit.ts
+++ b/src/common/blocks/submit.ts
@@ -419,17 +419,13 @@ export const NewSubmissionBlock = (pullRequest: PullRequest, isUpdate: boolean =
           type: 'section',
           text: {
             type: 'mrkdwn',
-            text: `*<${pullRequest.link}|${_capitalizeString(pullRequest.type)} - ${_capitalizeString(pullRequest.title)}>*`,
+            text: `*<@${pullRequest.author.id}> - <${pullRequest.link}|${_capitalizeString(pullRequest.type)} - ${_capitalizeString(pullRequest.title)}>*`,
           },
           accessory,
         },
         {
           type: 'section',
           fields: [
-            {
-              type: 'mrkdwn',
-              text: `*Author:*\n<@${pullRequest.author.id}>`,
-            },
             {
               type: 'mrkdwn',
               text: `*Project:*\n${pullRequest.project}`,

--- a/src/common/blocks/submit.ts
+++ b/src/common/blocks/submit.ts
@@ -419,13 +419,17 @@ export const NewSubmissionBlock = (pullRequest: PullRequest, isUpdate: boolean =
           type: 'section',
           text: {
             type: 'mrkdwn',
-            text: `<@${pullRequest.author.id}> submitted a pull request  :rocket:\n*<${pullRequest.link}|${_capitalizeString(pullRequest.type)} - ${_capitalizeString(pullRequest.title)}>*`,
+            text: `*<${pullRequest.link}|${_capitalizeString(pullRequest.type)} - ${_capitalizeString(pullRequest.title)}>*`,
           },
           accessory,
         },
         {
           type: 'section',
           fields: [
+            {
+              type: 'mrkdwn',
+              text: `*Author:*\n<@${pullRequest.author.id}>`,
+            },
             {
               type: 'mrkdwn',
               text: `*Project:*\n${pullRequest.project}`,

--- a/src/common/blocks/submit.ts
+++ b/src/common/blocks/submit.ts
@@ -413,7 +413,7 @@ export const NewSubmissionBlock = (pullRequest: PullRequest, isUpdate: boolean =
   return [
     {
       color: getAttachmentColor(pullRequest.status),
-      fallback: `*<@${pullRequest.author.id}> - <${pullRequest.link}|${_capitalizeString(pullRequest.type)} - ${_capitalizeString(pullRequest.title)}>*  :rocket:`,
+      fallback: `<@${pullRequest.author.id}> submitted a pull request  :rocket: \n*${_capitalizeString(pullRequest.type)} - ${_capitalizeString(pullRequest.title)}*`,
       blocks: [
         {
           type: 'section',


### PR DESCRIPTION
## What?
The PR link, type and title was moved up to the first line of the slack notification sent. ~And a new section was added for author~

## Why 
This was done to Enhance integration with Slack's `Later` feature 
Slack has a later feature which gives users the ability to mark important tasks or messages to be handled later. This feature is great and currently been used by some users to mark messages to be visited and handled later. However, it only shows the truncated top line of the message. The current structure of the slack notification sent makes this a hassle (check screenshot below).

## Screenshots
<img width="642" alt="image" src="https://github.com/Ritcheyy/vickpr-bot/assets/47315212/a8bf6387-2a1f-498e-b860-9f73aada0342">

## Edits 
- Author section was removed and author ID was added to top line
