### PR TITLE
Feature: Weekly Report

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,18 @@ $ npm run test:cov
 
 3. **Usage**: Use Slack slash commands to submit PR details and schedule reminders.
 
+### Weekly Report Configuration
+
+- Set `ENABLE_WEEKLY_REPORT=1` to activate the automated Thursday 3:00 PM report. Omit or set to `0` to disable.
+- Define `WEEKLY_REPORT_PROJECT_GROUPS` to map projects to the report groups. Example: `frontend:User Web App|Landing page;mobile:Mobile App;backend:API Repo`.
+- The bot posts a parent message with weekly totals followed by threaded updates for Frontend, Mobile, and Backend projects, or as configured.
+
 ### Roadmap
 
 - [x] Implement Slack slash commands for PR submission.
 - [x] Set up automated reminders for reviewers.
 - [x] Enhance Slack interaction with interactive messages for PR details submission.
-- [ ] Add Edit PR submission feature
+- [x] Add Edit PR submission feature
 - [ ] Add support for Nudging the reviewers of a pending PR
 - [ ] Add support for customizing reminder intervals.
 - [ ] Introduce advanced analytics and reporting features for PR performance tracking.

--- a/src/common/blocks/submit.ts
+++ b/src/common/blocks/submit.ts
@@ -1,6 +1,7 @@
 import { Types } from 'mongoose';
 import { PullRequest } from '@/pull-requests/schemas/pull-request.schema';
 import { FancyPrType, PullRequestStatus } from '../constants';
+import { getConfiguredProjects } from '@/common/config';
 import {
   _capitalizeString,
   _capitalizeWords,
@@ -11,15 +12,15 @@ import {
 } from '../helpers';
 
 export const SubmitPullRequestModalBlock = (userId: string = '') => {
-  const projects = getProjects();
+  const projects = getConfiguredProjects();
   const projectOptions =
     projects.map((project) => {
       return {
         text: {
           type: 'plain_text',
-          text: project.trim(),
+          text: project,
         },
-        value: project.trim(),
+        value: project,
       };
     }) || [];
 
@@ -424,7 +425,7 @@ export const SubmissionRequestBlock = () => {
 };
 
 export const EditPullRequestBlock = (pullRequest: PullRequest & { _id: Types.ObjectId }) => {
-  const projects = getProjects();
+  const projects = getConfiguredProjects();
   const projectOptions =
     projects.map((project) => {
       return {
@@ -657,9 +658,6 @@ export const EditPullRequestBlock = (pullRequest: PullRequest & { _id: Types.Obj
   };
 };
 
-const getProjects = () => {
-  return process.env.APP_PROJECTS?.split(',') || [];
-};
 
 const pullRequestTypes = [
   {

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -1,0 +1,64 @@
+// shared helpers for parsing env-driven configuration values
+const TRUTHY_ENV_VALUES = new Set(['1', 'true', 'yes', 'y', 'on']);
+
+const normalizeKey = (value: string): string => value.trim().toLowerCase();
+
+const parseEnvList = (value?: string, delimiter: string = ','): string[] => {
+  if (!value) {
+    return [];
+  }
+
+  return value
+    .split(delimiter)
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+};
+
+export const isWeeklyReportEnabled = (): boolean => {
+  const rawValue = process.env.ENABLE_WEEKLY_REPORT ?? '';
+
+  return TRUTHY_ENV_VALUES.has(rawValue.trim().toLowerCase());
+};
+
+export const getConfiguredProjects = (): string[] => {
+  return parseEnvList(process.env.APP_PROJECTS);
+};
+
+export const getWeeklyReportProjectGroupMap = (): Record<string, string> => {
+  const rawGroups = process.env.WEEKLY_REPORT_PROJECT_GROUPS;
+
+  if (!rawGroups) {
+    return {};
+  }
+
+  return rawGroups.split(';').reduce((acc, groupEntry) => {
+    const [groupKey, projectsRaw] = groupEntry.split(':');
+
+    if (!groupKey || !projectsRaw) {
+      return acc;
+    }
+
+    const normalizedGroup = normalizeKey(groupKey);
+
+    parseEnvList(projectsRaw, '|').forEach((projectName) => {
+      acc[normalizeKey(projectName)] = normalizedGroup;
+    });
+
+    return acc;
+  }, {} as Record<string, string>);
+};
+
+export const getWeeklyReportGroupOrder = (): string[] => {
+  return ['frontend', 'mobile', 'backend'];
+};
+
+export const resolveWeeklyReportGroupLabel = (groupKey: string): string => {
+  if (!groupKey) {
+    return '';
+  }
+
+  const trimmed = groupKey.trim();
+
+  return trimmed.charAt(0).toUpperCase() + trimmed.slice(1);
+};
+

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import { ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';

--- a/src/pull-requests/pull-requests.service.ts
+++ b/src/pull-requests/pull-requests.service.ts
@@ -1,5 +1,5 @@
 import * as moment from 'moment';
-import { isValidObjectId, Model } from 'mongoose';
+import { FilterQuery, isValidObjectId, Model } from 'mongoose';
 import { plainToInstance } from 'class-transformer';
 import { validateOrReject } from 'class-validator';
 import { InjectModel } from '@nestjs/mongoose';
@@ -136,6 +136,25 @@ export class PullRequestsService {
     return this.pullRequestModel
       .find({ status: { $nin: prClosedStatuses }, createdAt: { $gte: formattedDateLimit } })
       .sort({ createdAt: -1 });
+  }
+
+  /**
+   * Returns pull requests whose creation timestamp falls within the supplied window.
+   * Optionally restricts the results to a defined list of project identifiers.
+   */
+  async findCreatedBetween(startDate: Date, endDate: Date, projectFilter: string[] = []) {
+    const query: FilterQuery<PullRequest> = {
+      createdAt: {
+        $gte: startDate,
+        $lt: endDate,
+      },
+    };
+
+    if (projectFilter.length > 0) {
+      query.project = { $in: projectFilter };
+    }
+
+    return this.pullRequestModel.find(query).sort({ createdAt: 1 }).lean();
   }
 
   getNotificationDispatchType(status: string, hasTotalApprovals: boolean = false) {

--- a/src/slack/slack.controller.ts
+++ b/src/slack/slack.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { SlackService } from './slack.service';
 import { isWeeklyReportEnabled } from '@/common/config';

--- a/src/slack/slack.controller.ts
+++ b/src/slack/slack.controller.ts
@@ -1,13 +1,13 @@
 import { Controller, Get } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { SlackService } from './slack.service';
+import { isWeeklyReportEnabled } from '@/common/config';
 
 // Todo: move to config
 const MONDAY_TO_FRIDAY_AT_09_30AM = CronExpression.MONDAY_TO_FRIDAY_AT_09_30AM;
 const MONDAY_TO_FRIDAY_AT_1PM = CronExpression.MONDAY_TO_FRIDAY_AT_1PM;
 const MONDAY_TO_FRIDAY_AT_4PM = CronExpression.MONDAY_TO_FRIDAY_AT_4PM;
-// const THURSDAY_AT_3PM = '0 15 * * 4';
-const THURSDAY_AT_3PM = CronExpression.EVERY_30_SECONDS;
+const THURSDAY_AT_3PM = '0 15 * * 4';
 
 @Controller('slack')
 export class SlackController {
@@ -28,8 +28,7 @@ export class SlackController {
     return this.slackService.triggerReviewReminders();
   }
 
-  // @Cron(THURSDAY_AT_3PM)
-  @Get('test')
+  @Cron(THURSDAY_AT_3PM, { disabled: !isWeeklyReportEnabled() })
   handleWeeklyReportCron() {
     return this.slackService.triggerWeeklyReport();
   }

--- a/src/slack/slack.controller.ts
+++ b/src/slack/slack.controller.ts
@@ -1,4 +1,4 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Get } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { SlackService } from './slack.service';
 
@@ -6,6 +6,8 @@ import { SlackService } from './slack.service';
 const MONDAY_TO_FRIDAY_AT_09_30AM = CronExpression.MONDAY_TO_FRIDAY_AT_09_30AM;
 const MONDAY_TO_FRIDAY_AT_1PM = CronExpression.MONDAY_TO_FRIDAY_AT_1PM;
 const MONDAY_TO_FRIDAY_AT_4PM = CronExpression.MONDAY_TO_FRIDAY_AT_4PM;
+// const THURSDAY_AT_3PM = '0 15 * * 4';
+const THURSDAY_AT_3PM = CronExpression.EVERY_30_SECONDS;
 
 @Controller('slack')
 export class SlackController {
@@ -24,6 +26,12 @@ export class SlackController {
   @Cron(MONDAY_TO_FRIDAY_AT_4PM)
   handleEveningReminderCron() {
     return this.slackService.triggerReviewReminders();
+  }
+
+  // @Cron(THURSDAY_AT_3PM)
+  @Get('test')
+  handleWeeklyReportCron() {
+    return this.slackService.triggerWeeklyReport();
   }
 
   // For verifying the Request URL

--- a/src/slack/slack.service.ts
+++ b/src/slack/slack.service.ts
@@ -603,6 +603,7 @@ export class SlackService {
         PullRequestStatus.REVIEWING,
         PullRequestStatus.COMMENTED,
         PullRequestStatus.APPROVED,
+        PullRequestStatus.ON_HOLD,
       ]);
 
       const totalCount = includedPullRequests.length;
@@ -666,8 +667,9 @@ export class SlackService {
       pullRequests.length > 0
         ? pullRequests
             .map((pullRequest) => {
-              const statusLabel = _capitalizeWords(pullRequest.status);
-              const title = pullRequest.title || 'Untitled PR';
+              const statusLabel =
+                pullRequest.status === PullRequestStatus.MERGED ? 'Done' : 'In Progress';
+              const title = _capitalizeString(pullRequest.title) || 'Untitled PR';
 
               return `• ${title} → _${statusLabel}_`;
             })


### PR DESCRIPTION
# Weekly Report Feature

## Key Updates

- Add new env flag and project→group mapping config for weekly report toggling (`README.md`, `src/common/constants.ts` or small config utility).
- Extend `src/pull-requests/pull-requests.service.ts` with a range query helper for PRs created between two timestamps.
- Implement weekly report assembly/posting in `src/slack/slack.service.ts`, including summary counts and threaded group messages using existing Slack client.
- Register a Thursday 15:00 cron in `src/slack/slack.controller.ts` that calls the new service method when the feature flag is enabled.

## Config

- ENABLE_WEEKLY_REPORT: "1" to enable; unset/"0" disables.
- WEEKLY_REPORT_PROJECT_GROUPS: mapping of group→projects. Example:
- `frontend:Ritchey User App|Web;mobile:Ritchey Website Mobile;backend:API Project`
- APP_PROJECTS (existing): optional filter; the report will include only projects in this list if set.
- Unmapped projects are skipped (or default to `frontend` if requested later).